### PR TITLE
Added runtime.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.1.1 (WIP)
+
+- Added `meta/runtime.yml` (#7)
+
 ## v0.1.0 (2022-08-23)
 
 - Added repository to GitHub, moved from our closed-source internal repo. (#1)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: riskident
 name: luks
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.0
+version: 0.1.1
 
 readme: README.md
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,6 @@
+---
+# SPDX-FileCopyrightText: 2022 Risk.Ident GmbH <contact@riskident.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+requires_ansible: ">=2.10"


### PR DESCRIPTION
## Changes

- Added `meta/runtime.yml` with `requires_ansible` field

## Motivation

Was rejected from publishing because of this

```console
$ ansible-galaxy collection publish riskident-luks-0.1.0.tar.gz --token $ANSIBLE_GALAXY_TOKEN
Publishing collection artifact riskident-luks-0.1.0.tar.gz' to default https://galaxy.ansible.com/api/
Collection has been published to the Galaxy server default https://galaxy.ansible.com/api/
Waiting until Galaxy import task https://galaxy.ansible.com/api/v2/collection-imports/2xxxx/ has completed
ERROR! Galaxy import process failed: 'requires_ansible' in meta/runtime.yml is mandatory, but no meta/runtime.yml found (Code: None)
```

Question is what version we should support as minimum? I've picked 2.10 quite out-of-the-blue. 2.10 was released mid-2020, so it's only relatively new.

The `reboot_luks_ssh` action plugin is what's most affected by the Ansible version.

Docs: https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#meta-directory-and-runtime-yml

## Checklist

- [x] I've updated the `CHANGELOG.md` file, if relevant
- [x] I've updated the version in the `galaxy.yml` file, if relevant
