### PR TITLE
Fixed Dropbear default SSH command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.1.1 (WIP)
+
+- Fixed missing quotes in `dropbear_ssh_pub_keys_unlock_options` default SSH
+  restriction command in `initramfs_dropbear` role. (#8)
+
 ## v0.1.0 (2022-08-23)
 
 - Added repository to GitHub, moved from our closed-source internal repo. (#1)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: riskident
 name: luks
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.0
+version: 0.1.1
 
 readme: README.md
 

--- a/roles/initramfs_dropbear/defaults/main.yml
+++ b/roles/initramfs_dropbear/defaults/main.yml
@@ -12,7 +12,9 @@ dropbear_ssh_pub_keys_unlock: []
 
 # See "AUTHORIZED_KEYS FILE FORMAT" section in sshd(8) man page
 dropbear_ssh_pub_keys_unlock_options:
-  - command=/usr/bin/cryptroot-unlock
+  # Argument (the part after the equal sign =)
+  # must be quoted even if it doesn't contain any spaces.
+  - 'command="/usr/bin/cryptroot-unlock"'
   - no-port-forwarding
   - no-X11-forwarding
   - no-pty

--- a/roles/initramfs_network/defaults/main.yml
+++ b/roles/initramfs_network/defaults/main.yml
@@ -35,8 +35,6 @@ initramfs_network_bonds:
 #  - name: bond1
 #    interfaces: [ eth2, eth3 ]
 #    mac: aa:bb:cc:dd:ee:ff
-#    addr_cidr: 192.168.123.44/24
-#    gateway_ip: 192.168.123.1
 
 # Bonding driver options.
 # https://wiki.linuxfoundation.org/networking/bonding#bonding_driver_options


### PR DESCRIPTION
## Changes

- Fixed missing quotes in `dropbear_ssh_pub_keys_unlock_options` default SSH restriction command in `initramfs_dropbear` role

- Removed misleading comment.

## Motivation

Must have quotes. Was missing the quotes.

This is a port of a bugfix in our internal repo.

## Checklist

- [x] I've updated the `CHANGELOG.md` file, if relevant
- [x] I've updated the version in the `galaxy.yml` file, if relevant
