### PR TITLE
Added pre-run checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.1.2 (WIP)
+
+- Added support for "check mode". (#12)
+
 ## v0.1.1 (2022-08-29)
 
 - Added `meta/runtime.yml` (#7)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: riskident
 name: luks
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.1
+version: 0.1.2
 
 readme: README.md
 


### PR DESCRIPTION
## Changes

- Added checks before starting run based on <https://github.com/ansible/ansible/blob/v2.12.6/lib/ansible/plugins/action/reboot.py#L406-L420>, such as:

  - is `check_mode`?
  - is targeting local?

## Motivation

I've so far accidentally restarted some machines because of this :]

## Checklist

- [x] I've updated the `CHANGELOG.md` file, if relevant
- [x] I've updated the version in the `galaxy.yml` file, if relevant
