### PR TITLE
Added `luks_ssh_private_key` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added field `luks_ssh_private_key` for supplying SSH private key as
   raw string instead of using `luks_ssh_private_key_file`. (#13)
 
+  This is implemented by adding the private key to your ssh-agent. It is by
+  default added with the `-t 3600` flag, so the key is automatically removed
+  from your ssh-agent after 1 hour.
+
 ## v0.1.1 (2022-08-29)
 
 - Added `meta/runtime.yml` (#7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.1.2 (WIP)
+## v0.2.0 (WIP)
 
 - Added support for "check mode". (#12)
+
+- Added field `luks_ssh_private_key` for supplying SSH private key as
+  raw string instead of using `luks_ssh_private_key_file`. (#13)
 
 ## v0.1.1 (2022-08-29)
 

--- a/docs/reboot_luks_ssh.md
+++ b/docs/reboot_luks_ssh.md
@@ -179,7 +179,3 @@ In addition, `reboot_luks_ssh` also defines some additional return values:
 | unlocked | boolean | `true` | always   | true if the disk encryption was unlocked.
 
 <!--lint enable maximum-line-length-->
-
-## Author Information
-
-Created for <https://jira.2rioffice.com/browse/OP-1174>

--- a/docs/reboot_luks_ssh.md
+++ b/docs/reboot_luks_ssh.md
@@ -65,7 +65,8 @@ A role to install Dropbear into the initramfs can be found at
 [../../roles/initramfs\_dropbear](../../roles/initramfs_dropbear/README.md)
 
 When using `luks_ssh_private_key` (instead of `luks_ssh_private_key_file`),
-an ssh-agent must be running on the control-node (the machine that runs Ansible).
+an ssh-agent must be running on the control-node
+(the machine that runs Ansible).
 
 ### Installing Dropbear
 

--- a/docs/reboot_luks_ssh.md
+++ b/docs/reboot_luks_ssh.md
@@ -43,6 +43,17 @@ the disk encryption password remotely.
   These errors are swallowed and are only visible if you supply the `-vvv` flag
   to the ansible/ansible-playbook command.
 
+- When using `luks_ssh_private_key` (instead of `luks_ssh_private_key_file`)
+  then this action plugin will assume you have an ssh-agent running.
+  It will add the private key to your agent at the beginning of the task and
+  clean up at the end.
+
+  It will always try to remove the `luks_ssh_private_key` after the task,
+  no matter if it was registered there before or not. Do not reuse an SSH key
+  in the task that you would normally have added to your local ssh-agent,
+  or be prepared to `ssh-add` it back again after running this action plugin
+  when you need it for a manual SSH operation.
+
 ## Requirements
 
 Target machines must run an SSH server on boot to allow entering the LUKS
@@ -52,6 +63,9 @@ Such as by using [Dropbear](https://matt.ucc.asn.au/dropbear/dropbear.html).
 
 A role to install Dropbear into the initramfs can be found at
 [../../roles/initramfs\_dropbear](../../roles/initramfs_dropbear/README.md)
+
+When using `luks_ssh_private_key` (instead of `luks_ssh_private_key_file`),
+an ssh-agent must be running on the control-node (the machine that runs Ansible).
 
 ### Installing Dropbear
 
@@ -121,6 +135,7 @@ In addition, `reboot_luks_ssh` also defines some additional parameters:
 | `luks_ssh_port`             | int    | `1024` | SSH port of target machine when in LUKS boot (Dropbear)
 | `luks_ssh_user`             | string | `"root"` | SSH username used when connecting to LUKS boot (Dropbear)
 | `luks_ssh_private_key_file` | string | `ansible_ssh_private_key_file` (inventory param) | Path of SSH private key file, e.g `/home/ubuntu/.ssh/id_rsa`
+| `luks_ssh_private_key`      | string | `""` | Raw SSH private key text, e.g the content of your `~/.ssh/id_rsa` file
 | `luks_ssh_executable`       | string | `ansible_ssh_executable` (inventory param), or `"ssh"` | Command name of SSH executable used when connecting to LUKS boot (Dropbear)
 | `luks_ssh_connect_timeout`  | int    | `connect_timeout` (`ansible.builtin.reboot` param), or `600` | Connection timeout (in seconds) used when connecting to LUKS boot (Dropbear)
 | `luks_ssh_timeout`          | int    | `reboot_timeout` (`ansible.builtin.reboot` param) | Connection timeout (in seconds) for all connection retries in total, including the wait time between the retries.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: riskident
 name: luks
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.2
+version: 0.2.0
 
 readme: README.md
 

--- a/plugins/action/reboot_luks_ssh.py
+++ b/plugins/action/reboot_luks_ssh.py
@@ -363,4 +363,4 @@ class ActionModule(RebootActionModule):
             return result
 
         return self.run_reboot(
-            distribution, previous_boot_time, self.luks_password, task_vars)
+            distribution, previous_boot_time, task_vars)

--- a/plugins/action/reboot_luks_ssh.py
+++ b/plugins/action/reboot_luks_ssh.py
@@ -24,14 +24,17 @@
 # taken at 2022-06-08.
 
 from datetime import datetime
-import subprocess
-import time
-import tempfile
 import os
+import subprocess
+import tempfile
+import time
 
 from ansible.errors import AnsibleActionFail
 from ansible.module_utils._text import to_text
-from ansible.plugins.action.reboot import ActionModule as RebootActionModule, TimedOutException
+from ansible.plugins.action.reboot import (
+    ActionModule as RebootActionModule,
+    TimedOutException,
+)
 from ansible.utils.display import Display
 
 display = Display()

--- a/plugins/action/reboot_luks_ssh.py
+++ b/plugins/action/reboot_luks_ssh.py
@@ -57,6 +57,9 @@ class ActionModule(RebootActionModule):
         'luks_ssh_timeout',
         'luks_ssh_options',
         'post_unlock_delay',
+        'luks_ssh_keygen_executable',
+        'luks_ssh_add_executable',
+        'luks_ssh_add_timeout',
     ))
 
     # These delays actually speed up the process, as w/o them the script will:
@@ -74,8 +77,9 @@ class ActionModule(RebootActionModule):
     DEFAULT_LUKS_SSH_EXECUTABLE = "ssh"
     DEFAULT_LUKS_SSH_OPTIONS = [""]
     DEFAULT_LUKS_CONNECT_TIMEOUT = 600
-
-    _luks_ssh_private_key_tmp_file = None
+    DEFAULT_LUKS_SSH_KEYGEN_EXECUTABLE = "ssh-keygen"
+    DEFAULT_LUKS_SSH_ADD_EXECUTABLE = "ssh-add"
+    DEFAULT_LUKS_SSH_ADD_TIMEOUT = 3600
 
     def try_get_connection_option(self, option):
         try:
@@ -111,8 +115,6 @@ class ActionModule(RebootActionModule):
 
     @property
     def luks_ssh_private_key_file(self):
-        if self._luks_ssh_private_key_tmp_file:
-            return self._luks_ssh_private_key_tmp_file
         return self.get_task_arg('luks_ssh_private_key_file') or self.try_get_connection_option('ansible_ssh_private_key_file')
 
     @property
@@ -122,6 +124,18 @@ class ActionModule(RebootActionModule):
     @property
     def luks_ssh_executable(self):
         return self.get_task_arg("luks_ssh_executable") or self.try_get_connection_option("ansible_ssh_executable") or self.DEFAULT_LUKS_SSH_EXECUTABLE
+
+    @property
+    def luks_ssh_keygen_executable(self):
+        return self.get_task_arg("luks_ssh_keygen_executable") or self.DEFAULT_LUKS_SSH_KEYGEN_EXECUTABLE
+
+    @property
+    def luks_ssh_add_executable(self):
+        return self.get_task_arg("luks_ssh_add_executable") or self.DEFAULT_LUKS_SSH_ADD_EXECUTABLE
+
+    @property
+    def luks_ssh_add_timeout(self):
+        return self.get_task_arg("luks_ssh_add_timeout") or self.DEFAULT_LUKS_SSH_ADD_TIMEOUT
 
     @property
     def luks_ssh_connect_timeout(self):
@@ -179,10 +193,12 @@ class ActionModule(RebootActionModule):
             args.append('-o')
             args.append(opt)
 
-        private_key_file = self.luks_ssh_private_key_file
-        if private_key_file is not None:
-            args.append('-i')
-            args.append(private_key_file)
+        if not self.luks_ssh_private_key:
+            # Only add "-i" flag if we don't rely on ssh-agent
+            private_key_file = self.luks_ssh_private_key_file
+            if private_key_file is not None:
+                args.append('-i')
+                args.append(private_key_file)
 
         luks_ssh_user = self.luks_ssh_user
         if luks_ssh_user is not None:
@@ -295,27 +311,80 @@ class ActionModule(RebootActionModule):
         if not self.luks_ssh_private_key:
             raise AnsibleActionFail("luks_ssh_private_key_file or luks_ssh_private_key is required")
 
-        (fd, path) = tempfile.mkstemp(prefix="reboot_luks_ssh_")
-        self._luks_ssh_private_key_tmp_file = path
+        private_key = self.luks_ssh_private_key
+        public_key = self.private_key_to_public_key(private_key)
+        if self.is_public_key_added_to_ssh_agent(public_key):
+            # Skip as the key is already added
+            return
 
-        with open(fd, "w") as file:
-            file.write(self.luks_ssh_private_key)
+        self.add_private_key_to_ssh_agent(private_key)
 
-        display.vvv("{action}: created temporary key file: {path}".format(
-            action=self._task.action, path=path))
+    def private_key_to_public_key(self, private_key: str):
+        args = [
+            self.luks_ssh_keygen_executable,
+            "-y", # read private OpenSSH file, print OpenSSH public key
+            "-f", "/dev/stdin", # read from STDIN (not Windows compatible!)
+        ]
+        try:
+            display.vvv("{action}: Converting private key to public key via ssh-keygen".format(
+                action=self._task.action))
+            result = subprocess.run(
+                args,
+                stdout=subprocess.PIPE,  # capture STDOUT
+                stderr=subprocess.STDOUT,  # redirect STDERR to STDOUT
+                text=True,  # string input & output instead of bytes
+                input=str(private_key),
+                check=True)  # raise error on non-0 exit code
+            return result.stdout
+        except subprocess.CalledProcessError as e:
+            display.warning("{action}: Failed converting SSH private key to public key, output:\n{output}".format(
+                action=self._task.action, output=e.output))
+            raise
 
-    def cleanup(self, force=False):
-        if self._luks_ssh_private_key_tmp_file:
-            try:
-                os.remove(self._luks_ssh_private_key_tmp_file)
-                display.vvv("{action}: removed temporary key file: {path}".format(
-                    action=self._task.action, path=self._luks_ssh_private_key_tmp_file))
-                self._luks_ssh_private_key_tmp_file = None
-            except Exception as e:
-                display.warning("{action}: failed to remove temporary key file: {path}: {e}".format(
-                    action=self._task.action, path=self._luks_ssh_private_key_tmp_file, e=e))
+    def is_public_key_added_to_ssh_agent(self, public_key: str):
+        args = [
+            self.luks_ssh_add_executable,
+            "-T", # test if public key exists
+            "/dev/stdin", # read from STDIN (not Windows compatible!)
+        ]
+        try:
+            display.vvv("{action}: Checking if public key is added to ssh-agent via ssh-add".format(
+                action=self._task.action))
+            subprocess.run(
+                args,
+                stdout=subprocess.PIPE,  # capture STDOUT
+                stderr=subprocess.STDOUT,  # redirect STDERR to STDOUT
+                text=True,  # string input & output instead of bytes
+                input=str(public_key),
+                check=True)  # raise error on non-0 exit code
+            return True
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 1:
+                return False
+            display.warning("{action}: Failed checking if SSH public key is added to ssh-agent, output:\n{output}".format(
+                action=self._task.action, output=e.output))
+            raise
 
-        super(ActionModule, self).cleanup(force=force)
+    def add_private_key_to_ssh_agent(self, private_key: str):
+        args = [
+            self.luks_ssh_add_executable,
+            "-t", str(self.luks_ssh_add_timeout),
+            "-", # read from STDIN
+        ]
+        try:
+            display.vvv("{action}: Adding private key to ssh-agent via ssh-add".format(
+                action=self._task.action))
+            subprocess.run(
+                args,
+                stdout=subprocess.PIPE,  # capture STDOUT
+                stderr=subprocess.STDOUT,  # redirect STDERR to STDOUT
+                text=True,  # string input & output instead of bytes
+                input=str(private_key),
+                check=True)  # raise error on non-0 exit code
+        except subprocess.CalledProcessError as e:
+            display.warning("{action}: Failed adding private key to ssh-agent via ssh-add, output:\n{output}".format(
+                action=self._task.action, output=e.output))
+            raise
 
     def run(self, tmp=None, task_vars=None):
         self._supports_check_mode = True

--- a/plugins/action/reboot_luks_ssh.py
+++ b/plugins/action/reboot_luks_ssh.py
@@ -24,9 +24,7 @@
 # taken at 2022-06-08.
 
 from datetime import datetime
-import os
 import subprocess
-import tempfile
 import time
 
 from ansible.errors import AnsibleActionFail


### PR DESCRIPTION
## Changes

- Added fields:

  - `luks_ssh_private_key`
  - `luks_ssh_keygen_executable`, defaults to `ssh-keygen`
  - `luks_ssh_add_executable`, defaults to `ssh-add`
  - `luks_ssh_add_timeout`, defaults to `3600`

- If `luks_ssh_private_key` is provided, then it adds that key to your `ssh-agent` via `ssh-add`, and with an auto-delete timeout.
- It skips adding to `ssh-agent` if the key is already added.

## Motivation

Allows user to specify the SSH key via a variable, which allows user to store the key in an ansible-vault.

## Checklist

- [x] I've updated the `CHANGELOG.md` file, if relevant
- [x] I've updated the version in the `galaxy.yml` file, if relevant
