### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added field `luks_ssh_private_key` for supplying SSH private key as
   raw string instead of using `luks_ssh_private_key_file`. (#13)
 
-  This is implemented by adding the private key to your ssh-agent. It is by
-  default added with the `-t 3600` flag, so the key is automatically removed
-  from your ssh-agent after 1 hour.
+  This is implemented by adding the private key to your ssh-agent, and removing
+  it during the task's cleanup (when the task fails, is aborted, or finished).
+  The key is added by default with the `-t 3600` flag, so the key is
+  automatically removed from your ssh-agent after 1 hour, as a fallback if the
+  cleanup fails.
 
 ## v0.1.1 (2022-08-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.2.0 (WIP)
+## v0.2.0 (2022-11-02)
 
 - Added support for "check mode". (#12)
 


### PR DESCRIPTION
## Changes

- Added support for "check mode". (#12)

- Added field `luks_ssh_private_key` for supplying SSH private key as raw string instead of using `luks_ssh_private_key_file`. (#13)

  This is implemented by adding the private key to your ssh-agent, and removing it during the task's cleanup (when the task fails, is aborted, or finished). The key is added by default with the `-t 3600` flag, so the key is automatically removed from your ssh-agent after 1 hour, as a fallback if the cleanup fails.

## Checklist

- [x] I've updated the `(WIP)` tag to today's date in the `CHANGELOG.md` file
- [x] I've added the `release` label to this PR

## Actions after merge

- Follow steps in [CONTRIBUTING.md#Publishing a version](https://github.com/RiskIdent/ansible-collection-luks/blob/main/CONTRIBUTING.md#publishing-a-version)
