### PR TITLE
[OP-1528] Added "manual unlock" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.3.0 (WIP)
+
+- Added "manual unlock" feature, where you have to manually unlock the machine
+  if the `reboot_luks_ssh` action plugin succeeds in rebooting,
+  but fails to unlock it. (#15)
+
+- Added settings for cryptsetup-unlock output to consider failed unlock,
+  and will fail early instead of keep retrying an incorrect password. (#15)
+
+- Added args: (#15)
+
+  - `luks_stop_retry_on_output`
+  - `no_manual_unlock_on_fail`
+
+- Added missing documentation on args added in #13. (#15)
+
 ## v0.2.0 (2022-11-02)
 
 - Added support for "check mode". (#12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added args: (#15)
 
   - `luks_stop_retry_on_output`
-  - `no_manual_unlock_on_fail`
+  - `luks_manual_unlock_on_fail`
 
 - Added missing documentation on args added in #13. (#15)
 

--- a/docs/reboot_luks_ssh.md
+++ b/docs/reboot_luks_ssh.md
@@ -131,17 +131,22 @@ In addition, `reboot_luks_ssh` also defines some additional parameters:
 
 <!--lint disable maximum-line-length-->
 
-| Parameter                   | Type   | Default | Comments |
-| -------------------------   | ------ | ------- | -------- |
-| `luks_ssh_port`             | int    | `1024` | SSH port of target machine when in LUKS boot (Dropbear)
-| `luks_ssh_user`             | string | `"root"` | SSH username used when connecting to LUKS boot (Dropbear)
-| `luks_ssh_private_key_file` | string | `ansible_ssh_private_key_file` (inventory param) | Path of SSH private key file, e.g `/home/ubuntu/.ssh/id_rsa`
-| `luks_ssh_private_key`      | string | `""` | Raw SSH private key text, e.g the content of your `~/.ssh/id_rsa` file
-| `luks_ssh_executable`       | string | `ansible_ssh_executable` (inventory param), or `"ssh"` | Command name of SSH executable used when connecting to LUKS boot (Dropbear)
-| `luks_ssh_connect_timeout`  | int    | `connect_timeout` (`ansible.builtin.reboot` param), or `600` | Connection timeout (in seconds) used when connecting to LUKS boot (Dropbear)
-| `luks_ssh_timeout`          | int    | `reboot_timeout` (`ansible.builtin.reboot` param) | Connection timeout (in seconds) for all connection retries in total, including the wait time between the retries.
-| `luks_ssh_options`          | list\[string] | `[]` | Additional arbitrary SSH options used when connecting to LUKS boot (Dropbear), such as `PubkeyAcceptedKeyTypes`
-| `post_unlock_delay`         | int    | `0` | Time to wait (in seconds) after a successful LUKS unlock.
+| Parameter                    | Type   | Default | Comments |
+| ---------------------------- | ------ | ------- | -------- |
+| `luks_ssh_port`              | int    | `1024` | SSH port of target machine when in LUKS boot (Dropbear)
+| `luks_ssh_user`              | string | `"root"` | SSH username used when connecting to LUKS boot (Dropbear)
+| `luks_ssh_private_key_file`  | string | `ansible_ssh_private_key_file` (inventory param) | Path of SSH private key file, e.g `/home/ubuntu/.ssh/id_rsa`
+| `luks_ssh_private_key`       | string | `""` | Raw SSH private key text, e.g the content of your `~/.ssh/id_rsa` file
+| `luks_ssh_executable`        | string | `ansible_ssh_executable` (inventory param), or `"ssh"` | Command name of SSH executable used when connecting to LUKS boot (Dropbear)
+| `luks_ssh_connect_timeout`   | int    | `connect_timeout` (`ansible.builtin.reboot` param), or `600` | Connection timeout (in seconds) used when connecting to LUKS boot (Dropbear)
+| `luks_ssh_timeout`           | int    | `reboot_timeout` (`ansible.builtin.reboot` param) | Connection timeout (in seconds) for all connection retries in total, including the wait time between the retries.
+| `luks_ssh_options`           | list\[string] | `[]` | Additional arbitrary SSH options used when connecting to LUKS boot (Dropbear), such as `PubkeyAcceptedKeyTypes`
+| `post_unlock_delay`          | int    | `0` | Time to wait (in seconds) after a successful LUKS unlock.
+| `luks_ssh_keygen_executable` | string | `"ssh-keygen"` | The `ssh-keygen` executable to use when converting `luks_ssh_private_key` to a public key.
+| `luks_ssh_add_executable`    | string | `"ssh-add"` | The `ssh-add` executable to use when adding the `luks_ssh_private_key` to your SSH agent.
+| `luks_ssh_add_timeout`       | int    | `3600` | The `luks_ssh_private_key` key is automatically removed by the SSH agent after this many seconds, in case the `reboot_luks_ssh` action plugin fails to remove it by itself.
+| `luks_stop_retry_on_output`  | list\[string] | `["bad password", "maximum number of tries exceeded", "error", "timeout"]` | If the cryptroot-unlock's output contains any of these substrings (case insensitive) then stop retrying to unlock and fail early.
+| `luks_ssh_reconnect_timeout`  | int   | `3600` | Timeout for reconnecting after failing to unlock, waiting for manual unlock by human.
 
 <!--lint enable maximum-line-length-->
 

--- a/docs/reboot_luks_ssh.md
+++ b/docs/reboot_luks_ssh.md
@@ -147,7 +147,7 @@ In addition, `reboot_luks_ssh` also defines some additional parameters:
 | `luks_ssh_add_timeout`       | int    | `3600` | The `luks_ssh_private_key` key is automatically removed by the SSH agent after this many seconds, in case the `reboot_luks_ssh` action plugin fails to remove it by itself.
 | `luks_stop_retry_on_output`  | list\[string] | `["bad password", "maximum number of tries exceeded", "error", "timeout"]` | If the cryptroot-unlock's output contains any of these substrings (case insensitive) then stop retrying to unlock and fail early.
 | `luks_ssh_reconnect_timeout` | int    | `3600` | Timeout for reconnecting after failing to unlock, waiting for manual unlock by human.
-| `no_manual_unlock_on_fail`   | bool   | `false` | Disables feature of letting human manually unlock LUKS if the action plugin fails, and will instead fail the task.
+| `luks_manual_unlock_on_fail` | bool   | `true` | If true, the action plugin will prompt the human to manually unlock LUKS if the action plugin fails, instead of failing the task.
 
 <!--lint enable maximum-line-length-->
 

--- a/docs/reboot_luks_ssh.md
+++ b/docs/reboot_luks_ssh.md
@@ -146,7 +146,8 @@ In addition, `reboot_luks_ssh` also defines some additional parameters:
 | `luks_ssh_add_executable`    | string | `"ssh-add"` | The `ssh-add` executable to use when adding the `luks_ssh_private_key` to your SSH agent.
 | `luks_ssh_add_timeout`       | int    | `3600` | The `luks_ssh_private_key` key is automatically removed by the SSH agent after this many seconds, in case the `reboot_luks_ssh` action plugin fails to remove it by itself.
 | `luks_stop_retry_on_output`  | list\[string] | `["bad password", "maximum number of tries exceeded", "error", "timeout"]` | If the cryptroot-unlock's output contains any of these substrings (case insensitive) then stop retrying to unlock and fail early.
-| `luks_ssh_reconnect_timeout`  | int   | `3600` | Timeout for reconnecting after failing to unlock, waiting for manual unlock by human.
+| `luks_ssh_reconnect_timeout` | int    | `3600` | Timeout for reconnecting after failing to unlock, waiting for manual unlock by human.
+| `no_manual_unlock_on_fail`   | bool   | `false` | Disables feature of letting human manually unlock LUKS if the action plugin fails, and will instead fail the task.
 
 <!--lint enable maximum-line-length-->
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: riskident
 name: luks
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.2.0
+version: 0.3.0
 
 readme: README.md
 

--- a/plugins/action/reboot_luks_ssh.py
+++ b/plugins/action/reboot_luks_ssh.py
@@ -32,13 +32,13 @@ from ansible.errors import AnsibleActionFail
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils._text import to_text
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action.reboot import (
     ActionModule as RebootActionModule,
     TimedOutException,
 )
 from ansible.utils.display import Display
 from ansible.utils.display import Display
-from ansible.module_utils.parsing.convert_bool import boolean
 
 display = Display()
 
@@ -336,7 +336,8 @@ class ActionModule(RebootActionModule):
                 action=self._task.action, delay=post_reboot_delay))
             time.sleep(post_reboot_delay)
 
-        unlock_result = self.unlock_luks(distribution, previous_boot_time, task_vars)
+        unlock_result = self.unlock_luks(
+            distribution, previous_boot_time, task_vars)
         if unlock_result.get('failed'):
             self.set_result_elapsed(unlock_result, reboot_result['start'])
             return unlock_result


### PR DESCRIPTION
## Changes

- Added "manual unlock" feature, where you have to manually unlock the machine if the `reboot_luks_ssh` action plugin succeeds in rebooting, but fails to unlock it.
- Added settings for cryptsetup-unlock output to consider failed unlock, and will fail early instead of keep retrying an incorrect password.
- Added args:
  - `luks_stop_retry_on_output`
  - `no_manual_unlock_on_fail`
- Added missing documentation on args added in #13

## Motivation

Reboots are usually run last or in the middle of the playbook, so it's super annoying when it fails, and you have to rerun everything.

This makes it so the action plugin logs a message telling the operator to unlock the machine manually if it fails to unlock it, and then sits and waits until this is completed.

## Checklist

- [x] I've updated the `CHANGELOG.md` file, if relevant
- [x] I've updated the version in the `galaxy.yml` file, if relevant
