### PR TITLE
Added CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RiskIdent/platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Risk.Ident GmbH <contact@riskident.com>
+#
+# SPDX-License-Identifier: CC0-1.0
+
 * @RiskIdent/platform


### PR DESCRIPTION
## Changes

- Added `.github/CODEOWNERS` file, pointing towards @RiskIdent/platform

## Motivation

Will automatically assign our team members as reviewers
