### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.3.0 (WIP)
+## v0.3.0 (2023-01-17)
 
 - Added "manual unlock" feature, where you have to manually unlock the machine
   if the `reboot_luks_ssh` action plugin succeeds in rebooting,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.3.0 (2023-01-17)
+## v0.3.0 (2023-01-18)
 
 - Added "manual unlock" feature, where you have to manually unlock the machine
   if the `reboot_luks_ssh` action plugin succeeds in rebooting,


### PR DESCRIPTION
## Changes

- Added "manual unlock" feature, where you have to manually unlock the machine if the `reboot_luks_ssh` action plugin succeeds in rebooting, but fails to unlock it. (#15)

- Added settings for cryptsetup-unlock output to consider failed unlock, and will fail early instead of keep retrying an incorrect password. (#15)

- Added args: (#15)

  - `luks_stop_retry_on_output`
  - `luks_manual_unlock_on_fail`

- Added missing documentation on args added in #13. (#15)

## Checklist

- [x] I've updated the `(WIP)` tag to today's date in the `CHANGELOG.md` file
- [x] I've added the `release` label to this PR

## Actions after merge

- Follow steps in [CONTRIBUTING.md#Publishing a version](https://github.com/RiskIdent/ansible-collection-luks/blob/main/CONTRIBUTING.md#publishing-a-version)
