### PR TITLE
Fix issues in reboot_luks_ssh action plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v0.3.1 (WIP)
+
+- Fixed TypeError on datetime variables that were preventing the `reboot_luks_ssh` action plugin to succeeds in rebooting. (#20)
+
 ## v0.3.0 (2023-01-18)
 
 - Added "manual unlock" feature, where you have to manually unlock the machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v0.3.1 (WIP)
 
-- Fixed TypeError on datetime variables that were preventing the `reboot_luks_ssh` action plugin to succeeds in rebooting. (#20)
+- Fixed TypeError on datetime variables that were preventing the
+  `reboot_luks_ssh` action plugin to succeeds in rebooting. (#20)
 
 ## v0.3.0 (2023-01-18)
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: riskident
 name: luks
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.3.0
+version: 0.3.1
 
 readme: README.md
 

--- a/plugins/action/reboot_luks_ssh.py
+++ b/plugins/action/reboot_luks_ssh.py
@@ -23,7 +23,7 @@
 # https://github.com/ansible/ansible/blob/v2.12.6/lib/ansible/plugins/action/reboot.py
 # taken at 2022-06-08.
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from random import random
 import subprocess
 import time
@@ -322,7 +322,7 @@ class ActionModule(RebootActionModule):
         self._connection.reset()
 
     def set_result_elapsed(self, result: dict, start: datetime):
-        elapsed = datetime.utcnow() - start
+        elapsed = datetime.now(timezone.utc) - start
         result['elapsed'] = elapsed.seconds
 
     def run_reboot(self, distribution, previous_boot_time, task_vars):
@@ -438,14 +438,14 @@ class ActionModule(RebootActionModule):
         # RiskIdent: This function is taken directly from the ansible.builtin.reboot code
         # Changed sections are marked with a "# RiskIdent:" line comment
 
-        max_end_time = datetime.utcnow() + timedelta(seconds=reboot_timeout)
+        max_end_time = datetime.now(timezone.utc) + timedelta(seconds=reboot_timeout)
         if action_kwargs is None:
             action_kwargs = {}
 
         fail_count = 0
         max_fail_sleep = 12
 
-        while datetime.utcnow() < max_end_time:
+        while datetime.now(timezone.utc) < max_end_time:
             try:
                 action(**action_kwargs)
                 if action_desc:


### PR DESCRIPTION
- Fixes the datetime error that was blocking the unlock
- Updated with code from current ansible release where applicable

I'm not sure if it will work when providing the key as a string, I only tested the code with  the following parameters:

      luks_password: "{{ disk_encrypt_password }}"
      luks_ssh_private_key_file: "{{ dropbear_key_path }}"
      luks_ssh_port: "{{dropbear_port}}"