### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.3.1 (2023-03-04)
+## v0.3.1 (2025-02-27)
 
 - Fixed TypeError on datetime variables that were preventing the
   `reboot_luks_ssh` action plugin to succeeds in rebooting. (#20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v0.3.1 (WIP)
+## v0.3.1 (2023-03-04)
 
 - Fixed TypeError on datetime variables that were preventing the
   `reboot_luks_ssh` action plugin to succeeds in rebooting. (#20)


### PR DESCRIPTION
## Changes

- Fixed TypeError on datetime variables that were preventing the `reboot_luks_ssh` action plugin to succeeds in rebooting. (#20)

## Checklist

- [x] I've updated the `(WIP)` tag to today's date in the `CHANGELOG.md` file
- [x] I've added the `release` label to this PR

## Actions after merge

- Follow steps in [CONTRIBUTING.md#Publishing a version](https://github.com/RiskIdent/ansible-collection-luks/blob/main/CONTRIBUTING.md#publishing-a-version)
